### PR TITLE
Thrust expo: move to a new method

### DIFF
--- a/ThrustExpo/index.html
+++ b/ThrustExpo/index.html
@@ -17,6 +17,7 @@
         <script src="../modules/tabulator/dist/js/tabulator.min.js"></script>
         <script src="../Libraries/ParameterMetadata.js"></script>
         <script src="../Libraries/FileSaver.js"></script>
+        <script src="../Libraries/Array_Math.js"></script>
         <script src="ThrustExpo.js"></script>
     </head>
 


### PR DESCRIPTION
This moves to useing a new method for expo fit. The provided thrust data is used to create a lookup table which allows the AP equations to be used. The fit is then done by minimizing the standard deviation of the gradient (constant gradient is a straight line). 

The fit and gradient plot are just from spin min to spin max.

I have updated the thrust labels to remove units.